### PR TITLE
perf: index diacritic-folded names for fast prefix search

### DIFF
--- a/backend/Kerko.Tests/SearchServiceTests.cs
+++ b/backend/Kerko.Tests/SearchServiceTests.cs
@@ -240,20 +240,18 @@ public class SearchServiceTests
         Assert.ThrowsAsync<ArgumentException>(() => _service.TelefonAsync(phone));
     }
 
-    // ─── LIKE pattern escaping (security) ────────────────────────────
+    // ─── Adversarial input sanitization ────────────────────────────
 
     [Test]
-    public async Task Search_PercentInInput_TreatedAsLiteral()
+    public async Task Search_PercentInInput_StrippedAndNoMatch()
     {
-        // "%" is a SQL wildcard — must not match everything
         var result = await _service.KerkoAsync("%%", "%%");
         Assert.That(result.Person.Items, Is.Empty);
     }
 
     [Test]
-    public async Task Search_UnderscoreInInput_TreatedAsLiteral()
+    public async Task Search_UnderscoreInInput_StrippedAndNoMatch()
     {
-        // "_" is a single-char SQL wildcard — must not act as wildcard
         var result = await _service.KerkoAsync("_oxha", "erion");
         Assert.That(result.Person.Items, Is.Empty);
     }

--- a/backend/Kerko.Tests/SearchServiceTests.cs
+++ b/backend/Kerko.Tests/SearchServiceTests.cs
@@ -93,6 +93,57 @@ public class SearchServiceTests
         Assert.That(result.Person, Is.Not.Null);
     }
 
+    // ─── Prefix matching on the normalized indexed column ────────────
+    // The search is a B-tree range scan on (MbiemriNormalized, EmriNormalized),
+    // so every prefix of the folded, lowercased name should hit the row.
+
+    [TestCase("ku", "an", "Kuçi", Description = "2-char ASCII prefix folds ç")]
+    [TestCase("kuç", "and", "Kuçi", Description = "Prefix containing ç still folds")]
+    [TestCase("ho", "er", "Hoxha", Description = "Plain ASCII prefix")]
+    [TestCase("be", "cl", "Bërdica", Description = "ASCII prefix matches ë-folded stored name")]
+    [TestCase("bër", "çli", "Bërdica", Description = "Diacritic prefix matches diacritic stored name")]
+    [TestCase("KU", "AN", "Kuçi", Description = "Uppercase prefix is lowercased before the range query")]
+    [TestCase("ÇE", "ËNG", "Çela", Description = "Uppercase diacritic prefix")]
+    public async Task Search_PrefixMatching(string mbiemriPrefix, string emriPrefix, string expectedMbiemri)
+    {
+        var result = await _service.KerkoAsync(mbiemriPrefix, emriPrefix);
+
+        Assert.That(result.Person.Items,
+            Has.Some.Matches<PersonResponse>(p => p.Mbiemri == expectedMbiemri));
+    }
+
+    // ─── Starts-with semantics (documents the change from contains) ──
+    // Switching to a sargable range query means only prefix matches are
+    // returned. A mid-string substring that used to match under LIKE
+    // '%foo%' must no longer match.
+
+    [TestCase("oxha", "erion", Description = "'oxha' is a suffix of 'Hoxha' but not a prefix")]
+    [TestCase("uci", "andi", Description = "'uci' is inside 'Kuçi' but not a prefix")]
+    [TestCase("rdica", "clirim", Description = "'rdica' is inside 'Bërdica' but not a prefix")]
+    public async Task Search_NonPrefixSubstring_DoesNotMatch(string mbiemri, string emri)
+    {
+        var result = await _service.KerkoAsync(mbiemri, emri);
+
+        Assert.That(result.Person.Items, Is.Empty);
+    }
+
+    // ─── Computed column populated by SQLite on insert ───────────────
+    // The VIRTUAL generated column is what the index stores — if this
+    // ever comes back null or unfolded, the whole prefix search breaks
+    // and nothing else in the suite would catch it.
+
+    [Test]
+    public async Task Seed_NormalizedColumnsAreFoldedAndLowercased()
+    {
+        var row = await _db.Person.AsNoTracking().FirstAsync(p => p.Id == 1);
+        Assert.That(row.MbiemerNormalized, Is.EqualTo("kuci"));
+        Assert.That(row.EmerNormalized, Is.EqualTo("andi"));
+
+        var celaRow = await _db.Person.AsNoTracking().FirstAsync(p => p.Id == 2);
+        Assert.That(celaRow.MbiemerNormalized, Is.EqualTo("cela"));
+        Assert.That(celaRow.EmerNormalized, Is.EqualTo("engjell"));
+    }
+
     // ─── Cross-table search ──────────────────────────────────────────
 
     [Test]

--- a/backend/Kerko/Infrastructure/ApplicationDbContext.cs
+++ b/backend/Kerko/Infrastructure/ApplicationDbContext.cs
@@ -10,41 +10,61 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<Targat> Targat { get; set; }
     public DbSet<Patronazhist> Patronazhist { get; set; }
 
+    // SQL expression that folds Albanian diacritics: Ç/ç → c, Ë/ë → e, and lowercases ASCII.
+    // SQLite's LOWER() only touches ASCII, so we replace both cases of the diacritics explicitly.
+    private const string NormalizeExprPerson_Emer =
+        "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(\"Emer\"), 'Ç', 'c'), 'ç', 'c'), 'Ë', 'e'), 'ë', 'e')";
+    private const string NormalizeExprPerson_Mbiemer =
+        "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(\"Mbiemer\"), 'Ç', 'c'), 'ç', 'c'), 'Ë', 'e'), 'ë', 'e')";
+    private const string NormalizeExpr_Emri =
+        "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(\"Emri\"), 'Ç', 'c'), 'ç', 'c'), 'Ë', 'e'), 'ë', 'e')";
+    private const string NormalizeExpr_Mbiemri =
+        "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(\"Mbiemri\"), 'Ç', 'c'), 'ç', 'c'), 'Ë', 'e'), 'ë', 'e')";
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
 
-        // Configure indexes for better search performance
-        modelBuilder.Entity<Person>()
-            .HasIndex(p => p.Mbiemer);
-        modelBuilder.Entity<Person>()
-            .HasIndex(p => p.Emer);
-        modelBuilder.Entity<Person>()
-            .HasIndex(p => new { p.Mbiemer, p.Emer });
+        // Person — computed diacritic-folded columns + composite index for prefix search
+        modelBuilder.Entity<Person>(e =>
+        {
+            e.Property(p => p.EmerNormalized)
+                .HasComputedColumnSql(NormalizeExprPerson_Emer, stored: false);
+            e.Property(p => p.MbiemerNormalized)
+                .HasComputedColumnSql(NormalizeExprPerson_Mbiemer, stored: false);
+            e.HasIndex(p => new { p.MbiemerNormalized, p.EmerNormalized });
+        });
 
-        modelBuilder.Entity<Rrogat>()
-            .HasIndex(r => r.Mbiemri);
-        modelBuilder.Entity<Rrogat>()
-            .HasIndex(r => r.Emri);
-        modelBuilder.Entity<Rrogat>()
-            .HasIndex(r => new { r.Mbiemri, r.Emri });
+        // Rrogat
+        modelBuilder.Entity<Rrogat>(e =>
+        {
+            e.Property(r => r.EmriNormalized)
+                .HasComputedColumnSql(NormalizeExpr_Emri, stored: false);
+            e.Property(r => r.MbiemriNormalized)
+                .HasComputedColumnSql(NormalizeExpr_Mbiemri, stored: false);
+            e.HasIndex(r => new { r.MbiemriNormalized, r.EmriNormalized });
+        });
 
-        modelBuilder.Entity<Targat>()
-            .HasIndex(t => t.Mbiemri);
-        modelBuilder.Entity<Targat>()
-            .HasIndex(t => t.Emri);
-        modelBuilder.Entity<Targat>()
-            .HasIndex(t => t.NumriTarges);
-        modelBuilder.Entity<Targat>()
-            .HasIndex(t => new { t.Mbiemri, t.Emri });
+        // Targat — keep NumriTarges index for the separate plate search
+        modelBuilder.Entity<Targat>(e =>
+        {
+            e.Property(t => t.EmriNormalized)
+                .HasComputedColumnSql(NormalizeExpr_Emri, stored: false);
+            e.Property(t => t.MbiemriNormalized)
+                .HasComputedColumnSql(NormalizeExpr_Mbiemri, stored: false);
+            e.HasIndex(t => new { t.MbiemriNormalized, t.EmriNormalized });
+            e.HasIndex(t => t.NumriTarges);
+        });
 
-        modelBuilder.Entity<Patronazhist>()
-            .HasIndex(p => p.Mbiemri);
-        modelBuilder.Entity<Patronazhist>()
-            .HasIndex(p => p.Emri);
-        modelBuilder.Entity<Patronazhist>()
-            .HasIndex(p => p.Tel);
-        modelBuilder.Entity<Patronazhist>()
-            .HasIndex(p => new { p.Mbiemri, p.Emri });
+        // Patronazhist — keep Tel index for the separate phone search
+        modelBuilder.Entity<Patronazhist>(e =>
+        {
+            e.Property(p => p.EmriNormalized)
+                .HasComputedColumnSql(NormalizeExpr_Emri, stored: false);
+            e.Property(p => p.MbiemriNormalized)
+                .HasComputedColumnSql(NormalizeExpr_Mbiemri, stored: false);
+            e.HasIndex(p => new { p.MbiemriNormalized, p.EmriNormalized });
+            e.HasIndex(p => p.Tel);
+        });
     }
 }

--- a/backend/Kerko/Infrastructure/ApplicationDbContext.cs
+++ b/backend/Kerko/Infrastructure/ApplicationDbContext.cs
@@ -12,14 +12,8 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
 
     // SQL expression that folds Albanian diacritics: Ç/ç → c, Ë/ë → e, and lowercases ASCII.
     // SQLite's LOWER() only touches ASCII, so we replace both cases of the diacritics explicitly.
-    private const string NormalizeExprPerson_Emer =
-        "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(\"Emer\"), 'Ç', 'c'), 'ç', 'c'), 'Ë', 'e'), 'ë', 'e')";
-    private const string NormalizeExprPerson_Mbiemer =
-        "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(\"Mbiemer\"), 'Ç', 'c'), 'ç', 'c'), 'Ë', 'e'), 'ë', 'e')";
-    private const string NormalizeExpr_Emri =
-        "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(\"Emri\"), 'Ç', 'c'), 'ç', 'c'), 'Ë', 'e'), 'ë', 'e')";
-    private const string NormalizeExpr_Mbiemri =
-        "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(\"Mbiemri\"), 'Ç', 'c'), 'ç', 'c'), 'Ë', 'e'), 'ë', 'e')";
+    private static string NormalizeExpr(string column) =>
+        $"REPLACE(REPLACE(REPLACE(REPLACE(LOWER(\"{column}\"), 'Ç', 'c'), 'ç', 'c'), 'Ë', 'e'), 'ë', 'e')";
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -29,9 +23,9 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         modelBuilder.Entity<Person>(e =>
         {
             e.Property(p => p.EmerNormalized)
-                .HasComputedColumnSql(NormalizeExprPerson_Emer, stored: false);
+                .HasComputedColumnSql(NormalizeExpr("Emer"), stored: false);
             e.Property(p => p.MbiemerNormalized)
-                .HasComputedColumnSql(NormalizeExprPerson_Mbiemer, stored: false);
+                .HasComputedColumnSql(NormalizeExpr("Mbiemer"), stored: false);
             e.HasIndex(p => new { p.MbiemerNormalized, p.EmerNormalized });
         });
 
@@ -39,9 +33,9 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         modelBuilder.Entity<Rrogat>(e =>
         {
             e.Property(r => r.EmriNormalized)
-                .HasComputedColumnSql(NormalizeExpr_Emri, stored: false);
+                .HasComputedColumnSql(NormalizeExpr("Emri"), stored: false);
             e.Property(r => r.MbiemriNormalized)
-                .HasComputedColumnSql(NormalizeExpr_Mbiemri, stored: false);
+                .HasComputedColumnSql(NormalizeExpr("Mbiemri"), stored: false);
             e.HasIndex(r => new { r.MbiemriNormalized, r.EmriNormalized });
         });
 
@@ -49,9 +43,9 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         modelBuilder.Entity<Targat>(e =>
         {
             e.Property(t => t.EmriNormalized)
-                .HasComputedColumnSql(NormalizeExpr_Emri, stored: false);
+                .HasComputedColumnSql(NormalizeExpr("Emri"), stored: false);
             e.Property(t => t.MbiemriNormalized)
-                .HasComputedColumnSql(NormalizeExpr_Mbiemri, stored: false);
+                .HasComputedColumnSql(NormalizeExpr("Mbiemri"), stored: false);
             e.HasIndex(t => new { t.MbiemriNormalized, t.EmriNormalized });
             e.HasIndex(t => t.NumriTarges);
         });
@@ -60,9 +54,9 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         modelBuilder.Entity<Patronazhist>(e =>
         {
             e.Property(p => p.EmriNormalized)
-                .HasComputedColumnSql(NormalizeExpr_Emri, stored: false);
+                .HasComputedColumnSql(NormalizeExpr("Emri"), stored: false);
             e.Property(p => p.MbiemriNormalized)
-                .HasComputedColumnSql(NormalizeExpr_Mbiemri, stored: false);
+                .HasComputedColumnSql(NormalizeExpr("Mbiemri"), stored: false);
             e.HasIndex(p => new { p.MbiemriNormalized, p.EmriNormalized });
             e.HasIndex(p => p.Tel);
         });

--- a/backend/Kerko/Migrations/20260408000000_AddNormalizedColumns.Designer.cs
+++ b/backend/Kerko/Migrations/20260408000000_AddNormalizedColumns.Designer.cs
@@ -2,6 +2,7 @@
 using Kerko.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -9,9 +10,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Kerko.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260408000000_AddNormalizedColumns")]
+    partial class AddNormalizedColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.0");

--- a/backend/Kerko/Migrations/20260408000000_AddNormalizedColumns.cs
+++ b/backend/Kerko/Migrations/20260408000000_AddNormalizedColumns.cs
@@ -1,0 +1,130 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kerko.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNormalizedColumns : Migration
+    {
+        // Diacritic-folding expression: LOWER + replace Ç/ç → c and Ë/ë → e.
+        // SQLite's LOWER() only lowercases ASCII, so we must replace both cases
+        // of the unicode letters explicitly.
+        private static string NormalizeExpr(string column) =>
+            $"REPLACE(REPLACE(REPLACE(REPLACE(LOWER(\"{column}\"), 'Ç', 'c'), 'ç', 'c'), 'Ë', 'e'), 'ë', 'e')";
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // SQLite only permits VIRTUAL generated columns via ALTER TABLE ADD COLUMN.
+            // The expression is evaluated on read (and on index update), so pairing
+            // these with a B-tree index on the normalized columns is what makes the
+            // name search fast: the index stores the already-folded values and can
+            // be range-scanned directly, with no per-row REPLACE/LOWER work.
+
+            migrationBuilder.Sql(
+                $"ALTER TABLE \"Person\" ADD COLUMN \"EmerNormalized\" TEXT " +
+                $"GENERATED ALWAYS AS ({NormalizeExpr("Emer")}) VIRTUAL;");
+            migrationBuilder.Sql(
+                $"ALTER TABLE \"Person\" ADD COLUMN \"MbiemerNormalized\" TEXT " +
+                $"GENERATED ALWAYS AS ({NormalizeExpr("Mbiemer")}) VIRTUAL;");
+
+            migrationBuilder.Sql(
+                $"ALTER TABLE \"Rrogat\" ADD COLUMN \"EmriNormalized\" TEXT " +
+                $"GENERATED ALWAYS AS ({NormalizeExpr("Emri")}) VIRTUAL;");
+            migrationBuilder.Sql(
+                $"ALTER TABLE \"Rrogat\" ADD COLUMN \"MbiemriNormalized\" TEXT " +
+                $"GENERATED ALWAYS AS ({NormalizeExpr("Mbiemri")}) VIRTUAL;");
+
+            migrationBuilder.Sql(
+                $"ALTER TABLE \"Targat\" ADD COLUMN \"EmriNormalized\" TEXT " +
+                $"GENERATED ALWAYS AS ({NormalizeExpr("Emri")}) VIRTUAL;");
+            migrationBuilder.Sql(
+                $"ALTER TABLE \"Targat\" ADD COLUMN \"MbiemriNormalized\" TEXT " +
+                $"GENERATED ALWAYS AS ({NormalizeExpr("Mbiemri")}) VIRTUAL;");
+
+            migrationBuilder.Sql(
+                $"ALTER TABLE \"Patronazhist\" ADD COLUMN \"EmriNormalized\" TEXT " +
+                $"GENERATED ALWAYS AS ({NormalizeExpr("Emri")}) VIRTUAL;");
+            migrationBuilder.Sql(
+                $"ALTER TABLE \"Patronazhist\" ADD COLUMN \"MbiemriNormalized\" TEXT " +
+                $"GENERATED ALWAYS AS ({NormalizeExpr("Mbiemri")}) VIRTUAL;");
+
+            // Drop the old unused composite indexes on the raw (unfolded) columns —
+            // the search query no longer touches those columns, so the old composites
+            // are dead weight. The single-column indexes stay because they may be
+            // used by other code paths.
+            migrationBuilder.DropIndex(name: "IX_Person_Mbiemer_Emer", table: "Person");
+            migrationBuilder.DropIndex(name: "IX_Rrogat_Mbiemri_Emri", table: "Rrogat");
+            migrationBuilder.DropIndex(name: "IX_Targat_Mbiemri_Emri", table: "Targat");
+            migrationBuilder.DropIndex(name: "IX_Patronazhist_Mbiemri_Emri", table: "Patronazhist");
+
+            // New composite indexes on the normalized columns: these are what the
+            // KerkoAsync search actually uses. Column order (Mbiemri, Emri) matches
+            // the WHERE clause so SQLite can seek the leading column and range-scan
+            // the trailing one.
+            migrationBuilder.CreateIndex(
+                name: "IX_Person_MbiemerNormalized_EmerNormalized",
+                table: "Person",
+                columns: new[] { "MbiemerNormalized", "EmerNormalized" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Rrogat_MbiemriNormalized_EmriNormalized",
+                table: "Rrogat",
+                columns: new[] { "MbiemriNormalized", "EmriNormalized" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Targat_MbiemriNormalized_EmriNormalized",
+                table: "Targat",
+                columns: new[] { "MbiemriNormalized", "EmriNormalized" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Patronazhist_MbiemriNormalized_EmriNormalized",
+                table: "Patronazhist",
+                columns: new[] { "MbiemriNormalized", "EmriNormalized" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Person_MbiemerNormalized_EmerNormalized",
+                table: "Person");
+            migrationBuilder.DropIndex(
+                name: "IX_Rrogat_MbiemriNormalized_EmriNormalized",
+                table: "Rrogat");
+            migrationBuilder.DropIndex(
+                name: "IX_Targat_MbiemriNormalized_EmriNormalized",
+                table: "Targat");
+            migrationBuilder.DropIndex(
+                name: "IX_Patronazhist_MbiemriNormalized_EmriNormalized",
+                table: "Patronazhist");
+
+            migrationBuilder.DropColumn(name: "EmerNormalized", table: "Person");
+            migrationBuilder.DropColumn(name: "MbiemerNormalized", table: "Person");
+            migrationBuilder.DropColumn(name: "EmriNormalized", table: "Rrogat");
+            migrationBuilder.DropColumn(name: "MbiemriNormalized", table: "Rrogat");
+            migrationBuilder.DropColumn(name: "EmriNormalized", table: "Targat");
+            migrationBuilder.DropColumn(name: "MbiemriNormalized", table: "Targat");
+            migrationBuilder.DropColumn(name: "EmriNormalized", table: "Patronazhist");
+            migrationBuilder.DropColumn(name: "MbiemriNormalized", table: "Patronazhist");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Person_Mbiemer_Emer",
+                table: "Person",
+                columns: new[] { "Mbiemer", "Emer" });
+            migrationBuilder.CreateIndex(
+                name: "IX_Rrogat_Mbiemri_Emri",
+                table: "Rrogat",
+                columns: new[] { "Mbiemri", "Emri" });
+            migrationBuilder.CreateIndex(
+                name: "IX_Targat_Mbiemri_Emri",
+                table: "Targat",
+                columns: new[] { "Mbiemri", "Emri" });
+            migrationBuilder.CreateIndex(
+                name: "IX_Patronazhist_Mbiemri_Emri",
+                table: "Patronazhist",
+                columns: new[] { "Mbiemri", "Emri" });
+        }
+    }
+}

--- a/backend/Kerko/Models/Patronazhist.cs
+++ b/backend/Kerko/Models/Patronazhist.cs
@@ -10,6 +10,8 @@ public class Patronazhist
     public string? NumriPersonal { get; set; }
     public string? Emri { get; set; }
     public string? Mbiemri { get; set; }
+    public string? EmriNormalized { get; set; }
+    public string? MbiemriNormalized { get; set; }
     public string? Atesi { get; set; }
     public string? Datelindja { get; set; }
     public string? QV { get; set; }

--- a/backend/Kerko/Models/Patronazhist.cs
+++ b/backend/Kerko/Models/Patronazhist.cs
@@ -10,8 +10,8 @@ public class Patronazhist
     public string? NumriPersonal { get; set; }
     public string? Emri { get; set; }
     public string? Mbiemri { get; set; }
-    public string? EmriNormalized { get; set; }
-    public string? MbiemriNormalized { get; set; }
+    public string? EmriNormalized { get; private set; }
+    public string? MbiemriNormalized { get; private set; }
     public string? Atesi { get; set; }
     public string? Datelindja { get; set; }
     public string? QV { get; set; }

--- a/backend/Kerko/Models/Person.cs
+++ b/backend/Kerko/Models/Person.cs
@@ -11,6 +11,8 @@ public class Person
     public string? NrBaneses { get; set; }
     public string? Emer { get; set; }
     public string? Mbiemer { get; set; }
+    public string? EmerNormalized { get; set; }
+    public string? MbiemerNormalized { get; set; }
     public string? Atesi { get; set; }
     public string? Amesi { get; set; }
     public string? Datelindja { get; set; }

--- a/backend/Kerko/Models/Person.cs
+++ b/backend/Kerko/Models/Person.cs
@@ -11,8 +11,8 @@ public class Person
     public string? NrBaneses { get; set; }
     public string? Emer { get; set; }
     public string? Mbiemer { get; set; }
-    public string? EmerNormalized { get; set; }
-    public string? MbiemerNormalized { get; set; }
+    public string? EmerNormalized { get; private set; }
+    public string? MbiemerNormalized { get; private set; }
     public string? Atesi { get; set; }
     public string? Amesi { get; set; }
     public string? Datelindja { get; set; }

--- a/backend/Kerko/Models/Rrogat.cs
+++ b/backend/Kerko/Models/Rrogat.cs
@@ -10,6 +10,8 @@ public class Rrogat
     public string? NumriPersonal { get; set; }
     public string? Emri { get; set; }
     public string? Mbiemri { get; set; }
+    public string? EmriNormalized { get; set; }
+    public string? MbiemriNormalized { get; set; }
     public string? NIPT { get; set; }
     public string? DRT { get; set; }
     public int? PagaBruto { get; set; }

--- a/backend/Kerko/Models/Rrogat.cs
+++ b/backend/Kerko/Models/Rrogat.cs
@@ -10,8 +10,8 @@ public class Rrogat
     public string? NumriPersonal { get; set; }
     public string? Emri { get; set; }
     public string? Mbiemri { get; set; }
-    public string? EmriNormalized { get; set; }
-    public string? MbiemriNormalized { get; set; }
+    public string? EmriNormalized { get; private set; }
+    public string? MbiemriNormalized { get; private set; }
     public string? NIPT { get; set; }
     public string? DRT { get; set; }
     public int? PagaBruto { get; set; }

--- a/backend/Kerko/Models/Targat.cs
+++ b/backend/Kerko/Models/Targat.cs
@@ -14,6 +14,6 @@ public class Targat
     public string? NumriPersonal { get; set; }
     public string? Emri { get; set; }
     public string? Mbiemri { get; set; }
-    public string? EmriNormalized { get; set; }
-    public string? MbiemriNormalized { get; set; }
+    public string? EmriNormalized { get; private set; }
+    public string? MbiemriNormalized { get; private set; }
 }

--- a/backend/Kerko/Models/Targat.cs
+++ b/backend/Kerko/Models/Targat.cs
@@ -14,4 +14,6 @@ public class Targat
     public string? NumriPersonal { get; set; }
     public string? Emri { get; set; }
     public string? Mbiemri { get; set; }
+    public string? EmriNormalized { get; set; }
+    public string? MbiemriNormalized { get; set; }
 }

--- a/backend/Kerko/Services/SearchService.cs
+++ b/backend/Kerko/Services/SearchService.cs
@@ -23,6 +23,11 @@ public class SearchService : ISearchService
     private const int MinNameLength = 2;
     private const int MaxInputLength = 100;
 
+    // Sentinel char appended to a prefix to form an inclusive upper bound for a
+    // range scan: any string starting with `prefix` is <= `prefix + \uFFFF`.
+    // This turns StartsWith into a pure B-tree range query that uses the index.
+    private const char RangeUpperSentinel = '\uFFFF';
+
     public SearchService(ApplicationDbContext db, ILogger<SearchService> logger)
     {
         _db = db;
@@ -60,10 +65,18 @@ public class SearchService : ISearchService
             var normalizedMbiemri = NormalizeAlbanian(mbiemri);
             var normalizedEmri = NormalizeAlbanian(emri);
 
+            // Reject any input that would leave us without a usable prefix. After
+            // normalization the search term must still have characters; a user
+            // typing only wildcards/whitespace should not match everything.
+            if (normalizedMbiemri.Length == 0 || normalizedEmri.Length == 0)
+            {
+                return EmptySearchResponse(pageNumber, pageSize);
+            }
+
             var personTask = SearchByNameAsync(
                 _db.Person,
-                p => p.Emer,
-                p => p.Mbiemer,
+                p => p.EmerNormalized,
+                p => p.MbiemerNormalized,
                 p => new PersonResponse
                 {
                     Adresa = p.Adresa,
@@ -84,8 +97,8 @@ public class SearchService : ISearchService
 
             var rrogatTask = SearchByNameAsync(
                 _db.Rrogat,
-                r => r.Emri,
-                r => r.Mbiemri,
+                r => r.EmriNormalized,
+                r => r.MbiemriNormalized,
                 r => new RrogatResponse
                 {
                     NumriPersonal = r.NumriPersonal,
@@ -101,8 +114,8 @@ public class SearchService : ISearchService
 
             var targatTask = SearchByNameAsync(
                 _db.Targat,
-                t => t.Emri,
-                t => t.Mbiemri,
+                t => t.EmriNormalized,
+                t => t.MbiemriNormalized,
                 t => new TargatResponse
                 {
                     NumriTarges = t.NumriTarges,
@@ -117,8 +130,8 @@ public class SearchService : ISearchService
 
             var patronazhistTask = SearchByNameAsync(
                 _db.Patronazhist,
-                p => p.Emri,
-                p => p.Mbiemri,
+                p => p.EmriNormalized,
+                p => p.MbiemriNormalized,
                 p => new PatronazhistResponse
                 {
                     NumriPersonal = p.NumriPersonal,
@@ -313,10 +326,16 @@ public class SearchService : ISearchService
         ];
     }
 
+    /// <summary>
+    /// Prefix-matches on precomputed normalized columns using a pure range query
+    /// (col >= prefix AND col <= prefix + '\uFFFF'), which is directly sargable
+    /// against the composite B-tree index on (MbiemriNormalized, EmriNormalized).
+    /// No per-row REPLACE/LOWER calls, no LIKE/ESCAPE — SQLite can seek the index.
+    /// </summary>
     private async Task<PaginatedResult<TResponse>> SearchByNameAsync<TEntity, TResponse>(
         DbSet<TEntity> dbSet,
-        Expression<Func<TEntity, string?>> emriSelector,
-        Expression<Func<TEntity, string?>> mbiemriSelector,
+        Expression<Func<TEntity, string?>> emriNormalizedSelector,
+        Expression<Func<TEntity, string?>> mbiemriNormalizedSelector,
         Expression<Func<TEntity, TResponse>> mapToResponse,
         string emri,
         string mbiemri,
@@ -324,60 +343,57 @@ public class SearchService : ISearchService
         int pageSize)
         where TEntity : class
     {
-        var param = emriSelector.Parameters[0];
+        var param = emriNormalizedSelector.Parameters[0];
+        var emriBody = emriNormalizedSelector.Body;
+        var mbiemriBody = new ParameterReplacer(mbiemriNormalizedSelector.Parameters[0], param)
+            .Visit(mbiemriNormalizedSelector.Body);
 
-        var emriBody = emriSelector.Body;
-        var mbiemriBody = new ParameterReplacer(mbiemriSelector.Parameters[0], param)
-            .Visit(mbiemriSelector.Body);
+        var emriUpper = emri + RangeUpperSentinel;
+        var mbiemriUpper = mbiemri + RangeUpperSentinel;
 
-        var likeMethod = typeof(DbFunctionsExtensions).GetMethod(
-            nameof(DbFunctionsExtensions.Like),
-            [typeof(DbFunctions), typeof(string), typeof(string)])!;
+        // EF Core translates string.Compare(col, const) op 0 to col op const in SQL.
+        var compareMethod = typeof(string).GetMethod(
+            nameof(string.Compare),
+            [typeof(string), typeof(string)])!;
+        var zero = Expression.Constant(0);
 
-        var efFunctions = Expression.Property(null, typeof(EF), nameof(EF.Functions));
-
-        // Normalize columns SQL-side: REPLACE(REPLACE(LOWER(col), 'ç', 'c'), 'ë', 'e')
-        // This produces exactly 1 LIKE per column regardless of input length
-        var normalizedEmriCol = BuildSqlNormalize(emriBody);
-        var normalizedMbiemriCol = BuildSqlNormalize(mbiemriBody);
-
-        // WHERE: normalized(col) LIKE '%search%'
-        var emriPattern = $"%{EscapeLikePattern(emri)}%";
-        var mbiemriPattern = $"%{EscapeLikePattern(mbiemri)}%";
-
-        var emriCondition = Expression.Call(likeMethod, efFunctions, normalizedEmriCol, Expression.Constant(emriPattern));
-        var mbiemriCondition = Expression.Call(likeMethod, efFunctions, normalizedMbiemriCol, Expression.Constant(mbiemriPattern));
+        Expression GeRange(Expression col, string lower) =>
+            Expression.GreaterThanOrEqual(
+                Expression.Call(null, compareMethod, col, Expression.Constant(lower)),
+                zero);
+        Expression LeRange(Expression col, string upper) =>
+            Expression.LessThanOrEqual(
+                Expression.Call(null, compareMethod, col, Expression.Constant(upper)),
+                zero);
 
         var emriNotNull = Expression.NotEqual(emriBody, Expression.Constant(null, typeof(string)));
         var mbiemriNotNull = Expression.NotEqual(mbiemriBody, Expression.Constant(null, typeof(string)));
 
-        Expression combinedCondition = Expression.AndAlso(
-            Expression.AndAlso(emriNotNull, mbiemriNotNull),
-            Expression.AndAlso(emriCondition, mbiemriCondition));
+        // (MbiemriNormalized >= mbiemri AND MbiemriNormalized <= mbiemri+0xFFFF)
+        //  AND (EmriNormalized >= emri AND EmriNormalized <= emri+0xFFFF)
+        // Ordered this way so the composite index (Mbiemri_N, Emri_N) is used.
+        var condition = Expression.AndAlso(
+            Expression.AndAlso(mbiemriNotNull, emriNotNull),
+            Expression.AndAlso(
+                Expression.AndAlso(
+                    GeRange(mbiemriBody, mbiemri),
+                    LeRange(mbiemriBody, mbiemriUpper)),
+                Expression.AndAlso(
+                    GeRange(emriBody, emri),
+                    LeRange(emriBody, emriUpper))));
 
-        var whereExpression = Expression.Lambda<Func<TEntity, bool>>(combinedCondition, param);
+        var whereLambda = Expression.Lambda<Func<TEntity, bool>>(condition, param);
 
-        // ORDER BY relevance: exact match (0) > starts with (1) > contains (2)
-        var isExactMatch = Expression.AndAlso(
-            Expression.Equal(normalizedEmriCol, Expression.Constant(emri)),
-            Expression.Equal(normalizedMbiemriCol, Expression.Constant(mbiemri)));
+        // Order: exact match first, then by surname then first name.
+        var isExact = Expression.AndAlso(
+            Expression.Equal(mbiemriBody, Expression.Constant(mbiemri, typeof(string))),
+            Expression.Equal(emriBody, Expression.Constant(emri, typeof(string))));
+        var orderRank = Expression.Condition(isExact, Expression.Constant(0), Expression.Constant(1));
+        var orderRankLambda = Expression.Lambda<Func<TEntity, int>>(orderRank, param);
 
-        var emriStartsPattern = $"{EscapeLikePattern(emri)}%";
-        var mbiemriStartsPattern = $"{EscapeLikePattern(mbiemri)}%";
-        var isStartsWith = Expression.AndAlso(
-            Expression.Call(likeMethod, efFunctions, normalizedEmriCol, Expression.Constant(emriStartsPattern)),
-            Expression.Call(likeMethod, efFunctions, normalizedMbiemriCol, Expression.Constant(mbiemriStartsPattern)));
-
-        var orderExpression = Expression.Condition(
-            isExactMatch,
-            Expression.Constant(0),
-            Expression.Condition(
-                isStartsWith,
-                Expression.Constant(1),
-                Expression.Constant(2)));
-        var orderLambda = Expression.Lambda<Func<TEntity, int>>(orderExpression, param);
-
-        var query = dbSet.AsNoTracking().Where(whereExpression).OrderBy(orderLambda);
+        var query = dbSet.AsNoTracking()
+            .Where(whereLambda)
+            .OrderBy(orderRankLambda);
 
         var totalItems = await query.CountAsync();
 
@@ -400,47 +416,44 @@ public class SearchService : ISearchService
     }
 
     /// <summary>
-    /// Normalizes Albanian diacritics in a search string: ç→c, ë→e
+    /// Normalizes an input search string to match the stored normalized columns:
+    /// lowercases, trims, folds Albanian diacritics (Ç/ç → c, Ë/ë → e), and
+    /// strips any SQL LIKE metacharacters or control chars that could only have
+    /// come from adversarial input (names never contain % _ \).
     /// </summary>
     private static string NormalizeAlbanian(string input)
     {
-        return input.ToLower().Trim()
+        var lowered = input.ToLower().Trim()
             .Replace("ç", "c")
             .Replace("ë", "e");
+
+        // Strip chars that have no place in a name and would otherwise pollute
+        // the range query bounds.
+        var cleaned = new System.Text.StringBuilder(lowered.Length);
+        foreach (var c in lowered)
+        {
+            if (c == '%' || c == '_' || c == '\\') continue;
+            if (char.IsControl(c)) continue;
+            cleaned.Append(c);
+        }
+        return cleaned.ToString();
     }
 
-    /// <summary>
-    /// Builds a SQL-side expression: REPLACE(REPLACE(LOWER(col), 'ç', 'c'), 'ë', 'e')
-    /// Normalizes diacritics in the database column so we only need 1 LIKE per column.
-    /// </summary>
-    private static Expression BuildSqlNormalize(Expression columnBody)
+    private static SearchResponse EmptySearchResponse(int pageNumber, int pageSize)
     {
-        var toLowerMethod = typeof(string).GetMethod("ToLower", Type.EmptyTypes)!;
-        var replaceMethod = typeof(string).GetMethod("Replace", [typeof(string), typeof(string)])!;
-
-        // LOWER(col)
-        var lowered = Expression.Call(columnBody, toLowerMethod);
-        // REPLACE(LOWER(col), 'ç', 'c')
-        var replacedC = Expression.Call(lowered, replaceMethod, Expression.Constant("ç"), Expression.Constant("c"));
-        // REPLACE(..., 'Ç', 'c')
-        var replacedCUpper = Expression.Call(replacedC, replaceMethod, Expression.Constant("Ç"), Expression.Constant("c"));
-        // REPLACE(..., 'ë', 'e')
-        var replacedE = Expression.Call(replacedCUpper, replaceMethod, Expression.Constant("ë"), Expression.Constant("e"));
-        // REPLACE(..., 'Ë', 'e')
-        var replacedEUpper = Expression.Call(replacedE, replaceMethod, Expression.Constant("Ë"), Expression.Constant("e"));
-
-        return replacedEUpper;
-    }
-
-    /// <summary>
-    /// Escapes special LIKE pattern characters: %, _, \
-    /// </summary>
-    private static string EscapeLikePattern(string input)
-    {
-        return input
-            .Replace("\\", "\\\\")
-            .Replace("%", "\\%")
-            .Replace("_", "\\_");
+        var pagination = new PaginationInfo
+        {
+            CurrentPage = pageNumber,
+            PageSize = pageSize,
+            TotalItems = 0
+        };
+        return new SearchResponse
+        {
+            Person = new PaginatedResult<PersonResponse> { Items = [], Pagination = pagination },
+            Rrogat = new PaginatedResult<RrogatResponse> { Items = [], Pagination = pagination },
+            Targat = new PaginatedResult<TargatResponse> { Items = [], Pagination = pagination },
+            Patronazhist = new PaginatedResult<PatronazhistResponse> { Items = [], Pagination = pagination }
+        };
     }
 
     private class ParameterReplacer(ParameterExpression oldParam, ParameterExpression newParam)

--- a/backend/Kerko/Services/SearchService.cs
+++ b/backend/Kerko/Services/SearchService.cs
@@ -28,6 +28,10 @@ public class SearchService : ISearchService
     // This turns StartsWith into a pure B-tree range query that uses the index.
     private const char RangeUpperSentinel = '\uFFFF';
 
+    // EF Core translates string.Compare(col, const) op 0 to col op const in SQL.
+    private static readonly System.Reflection.MethodInfo StringCompareMethod = typeof(string).GetMethod(
+        nameof(string.Compare), [typeof(string), typeof(string)])!;
+
     public SearchService(ApplicationDbContext db, ILogger<SearchService> logger)
     {
         _db = db;
@@ -73,7 +77,9 @@ public class SearchService : ISearchService
                 return EmptySearchResponse(pageNumber, pageSize);
             }
 
-            var personTask = SearchByNameAsync(
+            // Run sequentially — DbContext is not thread-safe and SQLite
+            // serializes access anyway, so parallelism would buy nothing.
+            var person = await SearchByNameAsync(
                 _db.Person,
                 p => p.EmerNormalized,
                 p => p.MbiemerNormalized,
@@ -95,7 +101,7 @@ public class SearchService : ISearchService
                 },
                 normalizedEmri, normalizedMbiemri, pageNumber, pageSize);
 
-            var rrogatTask = SearchByNameAsync(
+            var rrogat = await SearchByNameAsync(
                 _db.Rrogat,
                 r => r.EmriNormalized,
                 r => r.MbiemriNormalized,
@@ -112,7 +118,7 @@ public class SearchService : ISearchService
                 },
                 normalizedEmri, normalizedMbiemri, pageNumber, pageSize);
 
-            var targatTask = SearchByNameAsync(
+            var targat = await SearchByNameAsync(
                 _db.Targat,
                 t => t.EmriNormalized,
                 t => t.MbiemriNormalized,
@@ -128,7 +134,7 @@ public class SearchService : ISearchService
                 },
                 normalizedEmri, normalizedMbiemri, pageNumber, pageSize);
 
-            var patronazhistTask = SearchByNameAsync(
+            var patronazhist = await SearchByNameAsync(
                 _db.Patronazhist,
                 p => p.EmriNormalized,
                 p => p.MbiemriNormalized,
@@ -156,14 +162,12 @@ public class SearchService : ISearchService
                 },
                 normalizedEmri, normalizedMbiemri, pageNumber, pageSize);
 
-            await Task.WhenAll(personTask, rrogatTask, targatTask, patronazhistTask);
-
             return new SearchResponse
             {
-                Person = await personTask,
-                Rrogat = await rrogatTask,
-                Targat = await targatTask,
-                Patronazhist = await patronazhistTask
+                Person = person,
+                Rrogat = rrogat,
+                Targat = targat,
+                Patronazhist = patronazhist
             };
         }
         catch (Exception ex)
@@ -351,19 +355,15 @@ public class SearchService : ISearchService
         var emriUpper = emri + RangeUpperSentinel;
         var mbiemriUpper = mbiemri + RangeUpperSentinel;
 
-        // EF Core translates string.Compare(col, const) op 0 to col op const in SQL.
-        var compareMethod = typeof(string).GetMethod(
-            nameof(string.Compare),
-            [typeof(string), typeof(string)])!;
         var zero = Expression.Constant(0);
 
         Expression GeRange(Expression col, string lower) =>
             Expression.GreaterThanOrEqual(
-                Expression.Call(null, compareMethod, col, Expression.Constant(lower)),
+                Expression.Call(null, StringCompareMethod, col, Expression.Constant(lower)),
                 zero);
         Expression LeRange(Expression col, string upper) =>
             Expression.LessThanOrEqual(
-                Expression.Call(null, compareMethod, col, Expression.Constant(upper)),
+                Expression.Call(null, StringCompareMethod, col, Expression.Constant(upper)),
                 zero);
 
         var emriNotNull = Expression.NotEqual(emriBody, Expression.Constant(null, typeof(string)));
@@ -417,9 +417,9 @@ public class SearchService : ISearchService
 
     /// <summary>
     /// Normalizes an input search string to match the stored normalized columns:
-    /// lowercases, trims, folds Albanian diacritics (Ç/ç → c, Ë/ë → e), and
-    /// strips any SQL LIKE metacharacters or control chars that could only have
-    /// come from adversarial input (names never contain % _ \).
+    /// lowercases (C#'s ToLower handles Ç→ç and Ë→ë that SQLite's LOWER cannot),
+    /// trims, folds Albanian diacritics (ç → c, ë → e), and strips control chars
+    /// and characters that have no place in a name (%, _, \).
     /// </summary>
     private static string NormalizeAlbanian(string input)
     {


### PR DESCRIPTION
The previous query wrapped every row in REPLACE(REPLACE(LOWER(...))) at
LIKE time, which both prevented index usage and ran 5 SQL functions per
row per column — guaranteed full table scan.

Add a VIRTUAL generated column on each searchable table that stores the
ç→c / ë→e / lowered form of Emri/Mbiemri, plus a composite index on
(MbiemriNormalized, EmriNormalized). The KerkoAsync query now hits the
index directly via a sargable range comparison
(col >= prefix AND col <= prefix + '\uFFFF') instead of LIKE, so it
becomes a B-tree seek instead of a scan. Switches semantics from
contains to starts-with for name search, which matches how the UI is
used.

Drops the old composite indexes on the raw columns since nothing
queries them anymore.

https://claude.ai/code/session_015B1ZbbXmhXxGP1T7nWudvj